### PR TITLE
Refactor session management and add comprehensive tests

### DIFF
--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -14,3 +14,7 @@ export const PASSKEY_NOT_FOUND_ERROR_MESSAGE = 'Passkey not found.';
 export const USER_NOT_LOGGED_IN_MESSAGE = 'User not logged in.';
 export const ADD_TO_CART_MISSING_FIELDS_ERROR_MESSAGE = 'Missing Fields. Failed to add to cart.';
 export const ORDER_PRODUCTS_MISSING_FIELDS_ERROR_MESSAGE = 'Missing Fields. Failed to order products.';
+
+export const WEBAUTHN_SESSION_ID_COOKIE_NAME = 'w-session-id';
+export const WEBAUTHN_SESSION_PREFIX = 'techwear-shop-webauthn-session-';
+export const WEBAUTHN_SESSION_TTL = 5 * 60;

--- a/app/lib/session.test.ts
+++ b/app/lib/session.test.ts
@@ -1,4 +1,5 @@
 import {
+  deleteCurrentWebauthnSession,
   getCurrentWebauthnSession,
   getWebauthnSession,
   setWebauthnSession,
@@ -13,12 +14,23 @@ import { WEBAUTHN_SESSION_ID_COOKIE_NAME, WEBAUTHN_SESSION_PREFIX, WEBAUTHN_SESS
 jest.mock('./redis', () => ({
   get: jest.fn(),
   set: jest.fn(),
+  del: jest.fn(),
 }));
 jest.mock('next/headers', () => ({
   cookies: jest.fn(),
 }));
 
 describe('session', () => {
+  const expectedRandomNumber = 0.6;
+
+  beforeAll(() => {
+    jest.spyOn(Math, 'random').mockReturnValue(expectedRandomNumber);
+  });
+
+  afterAll(() => {
+    (Math.random as jest.Mock).mockRestore();
+  });
+
   describe('getWebauthnSession', () => {
     test('no session', async () => {
       // Arrange
@@ -76,16 +88,6 @@ describe('session', () => {
   });
 
   describe('getCurrentWebauthnSession', () => {
-    const expectedRandomNumber = 0.6;
-
-    beforeAll(() => {
-      jest.spyOn(Math, 'random').mockReturnValue(expectedRandomNumber);
-    });
-
-    afterAll(() => {
-      (Math.random as jest.Mock).mockRestore();
-    });
-
     test('no cookie present', async () => {
       // Arrange
       const expectedChallenge = undefined;
@@ -175,6 +177,97 @@ describe('session', () => {
       expect(mockCookies).toHaveBeenCalled();
       expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
       expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
+    });
+  });
+
+
+  describe('deleteSession', () => {
+    test('no cookie present', async () => {
+      // Arrange
+      const expectedChallenge = undefined;
+      const expectedSessionId = 'lllllllllle';
+      const expectedSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
+      const expectedSessionString = JSON.stringify(expectedSessionData);
+      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+      const expectedExpirationArgument = 'EX';
+      const expectedCookieValue: RequestCookie | undefined = undefined;
+      const mockCookieStore = {
+        get: jest.fn().mockReturnValue(expectedCookieValue),
+        set: jest.fn(),
+      };
+      (mockCookies as jest.Mock).mockResolvedValue(mockCookieStore);
+
+      // Act
+      await deleteCurrentWebauthnSession();
+
+      // Assert
+      expect(mockCookies).toHaveBeenCalled();
+      expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
+      expect(mockCookieStore.set).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME, expectedSessionId);
+      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
+      expect(mockRedis.del).toHaveBeenCalledWith(expectedRedisKey);
+    });
+
+    test('cookie exists but session is missing/expired on redis', async () => {
+      // Arrange
+      const expectedChallenge = undefined;
+      const expectedSessionId = 'lllllllllle';
+      const expectedSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
+      const expectedSessionString = JSON.stringify(expectedSessionData);
+      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+      const expectedExpirationArgument = 'EX';
+      const expectedCookieValue: RequestCookie | undefined = {
+        name: WEBAUTHN_SESSION_ID_COOKIE_NAME,
+        value: expectedSessionId,
+      };
+      const mockCookieStore = {
+        get: jest.fn().mockReturnValue(expectedCookieValue),
+        set: jest.fn(),
+      };
+      (mockCookies as jest.Mock).mockResolvedValue(mockCookieStore);
+      (mockRedis.get as jest.Mock).mockResolvedValue(null);
+
+
+      // Act
+      await deleteCurrentWebauthnSession();
+
+      // Assert
+      expect(mockCookies).toHaveBeenCalled();
+      expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
+      expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
+      expect(mockCookieStore.set).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME, expectedSessionId);
+      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
+      expect(mockRedis.del).toHaveBeenCalledWith(expectedRedisKey);
+    });
+
+    test('cookie exists and session is present on redis', async () => {
+      // Arrange
+      const expectedChallenge = 'challenge';
+      const expectedUsername = 'test';
+      const expectedSessionId = 'lllllllllle';
+      const expectedSessionData: WebauthnSessionData = { username: expectedUsername, currentChallenge: expectedChallenge };
+      const expectedSessionString = JSON.stringify(expectedSessionData);
+      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+      const expectedCookieValue: RequestCookie | undefined = {
+        name: WEBAUTHN_SESSION_ID_COOKIE_NAME,
+        value: expectedSessionId,
+      };
+      const mockCookieStore = {
+        get: jest.fn().mockReturnValue(expectedCookieValue),
+        set: jest.fn(),
+      };
+      (mockCookies as jest.Mock).mockResolvedValue(mockCookieStore);
+      (mockRedis.get as jest.Mock).mockResolvedValue(expectedSessionString);
+
+
+      // Act
+      await deleteCurrentWebauthnSession();
+
+      // Assert
+      expect(mockCookies).toHaveBeenCalled();
+      expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
+      expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
+      expect(mockRedis.del).toHaveBeenCalledWith(expectedRedisKey);
     });
   });
 });

--- a/app/lib/session.test.ts
+++ b/app/lib/session.test.ts
@@ -22,7 +22,7 @@ describe('session', () => {
   describe('getWebauthnSession', () => {
     test('no session', async () => {
       // Arrange
-      const expectedSession: WebauthnSessionData = {};
+      const expectedSession = null;
       const expectedSessionString = null;
       const expectedSessionId = '1234567890';
       const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;

--- a/app/lib/session.test.ts
+++ b/app/lib/session.test.ts
@@ -1,0 +1,180 @@
+import {
+  getCurrentWebauthnSession,
+  getWebauthnSession,
+  setWebauthnSession,
+  WebauthnSessionData,
+} from './session';
+
+import mockRedis from './redis';
+import { cookies as mockCookies } from 'next/headers';
+import { RequestCookie } from 'next/dist/compiled/@edge-runtime/cookies';
+import { WEBAUTHN_SESSION_ID_COOKIE_NAME, WEBAUTHN_SESSION_PREFIX, WEBAUTHN_SESSION_TTL } from './constants';
+
+jest.mock('./redis', () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+describe('session', () => {
+  describe('getWebauthnSession', () => {
+    test('no session', async () => {
+      // Arrange
+      const expectedSession: WebauthnSessionData = {};
+      const expectedSessionString = null;
+      const expectedSessionId = '1234567890';
+      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+      (mockRedis.get as jest.Mock).mockResolvedValue(expectedSessionString);
+
+      // Act
+      const actualSession = await getWebauthnSession(expectedSessionId);
+
+      // Assert
+      expect(actualSession).toEqual(expectedSession);
+      expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
+    });
+
+
+    test('session exists on redis', async () => {
+      // Arrange
+      const expectedUsername = 'test';
+      const expectedChallenge = 'challenge';
+      const expectedSessionId = '1234567890';
+      const expectedSession: WebauthnSessionData = { username: expectedUsername, currentChallenge: expectedChallenge };
+      const expectedSessionString = JSON.stringify(expectedSession);
+      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+      (mockRedis.get as jest.Mock).mockResolvedValue(expectedSessionString);
+
+      // Act
+      const actualSession = await getWebauthnSession(expectedSessionId);
+
+      // Assert
+      expect(actualSession).toEqual(expectedSession);
+      expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
+    });
+
+  });
+
+  test('setWebauthnSession', async () => {
+    // Arrange
+    const expectedUsername = 'test';
+    const expectedChallenge = 'challenge';
+    const expectedSessionId = '1234567890';
+    const expectedSessionData: WebauthnSessionData = { username: expectedUsername, currentChallenge: expectedChallenge };
+    const expectedSessionString = JSON.stringify(expectedSessionData);
+    const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+    const expectedExpirationArgument = 'EX';
+
+
+    // Act
+    await setWebauthnSession(expectedSessionId, expectedSessionData);
+
+    // Assert
+    expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
+  });
+
+  describe('getCurrentWebauthnSession', () => {
+    const expectedRandomNumber = 0.6;
+
+    beforeAll(() => {
+      jest.spyOn(Math, 'random').mockReturnValue(expectedRandomNumber);
+    });
+
+    afterAll(() => {
+      (Math.random as jest.Mock).mockRestore();
+    });
+
+    test('no cookie present', async () => {
+      // Arrange
+      const expectedChallenge = undefined;
+      const expectedSessionId = 'lllllllllle';
+      const expectedSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
+      const expectedSession = { sessionId: expectedSessionId, data: expectedSessionData };
+      const expectedSessionString = JSON.stringify(expectedSessionData);
+      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+      const expectedExpirationArgument = 'EX';
+      const expectedCookieValue: RequestCookie | undefined = undefined;
+      const mockCookieStore = {
+        get: jest.fn().mockReturnValue(expectedCookieValue),
+        set: jest.fn(),
+      };
+      (mockCookies as jest.Mock).mockResolvedValue(mockCookieStore);
+
+      // Act
+      const actualSession = await getCurrentWebauthnSession();
+
+      // Assert
+      expect(actualSession).toEqual(expectedSession);
+      expect(mockCookies).toHaveBeenCalled();
+      expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
+      expect(mockCookieStore.set).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME, expectedSessionId);
+      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
+    });
+
+    test('cookie exists but session is missing/expired on redis', async () => {
+      // Arrange
+      const expectedChallenge = undefined;
+      const expectedSessionId = 'lllllllllle';
+      const expectedSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
+      const expectedSession = { sessionId: expectedSessionId, data: expectedSessionData };
+      const expectedSessionString = JSON.stringify(expectedSessionData);
+      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+      const expectedExpirationArgument = 'EX';
+      const expectedCookieValue: RequestCookie | undefined = {
+        name: WEBAUTHN_SESSION_ID_COOKIE_NAME,
+        value: expectedSessionId,
+      };
+      const mockCookieStore = {
+        get: jest.fn().mockReturnValue(expectedCookieValue),
+        set: jest.fn(),
+      };
+      (mockCookies as jest.Mock).mockResolvedValue(mockCookieStore);
+      (mockRedis.get as jest.Mock).mockResolvedValue(null);
+
+
+      // Act
+      const actualSession = await getCurrentWebauthnSession();
+
+      // Assert
+      expect(actualSession).toEqual(expectedSession);
+      expect(mockCookies).toHaveBeenCalled();
+      expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
+      expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
+      expect(mockCookieStore.set).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME, expectedSessionId);
+      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
+    });
+
+    test('cookie exists and session is present on redis', async () => {
+      // Arrange
+      const expectedChallenge = 'challenge';
+      const expectedUsername = 'test';
+      const expectedSessionId = 'lllllllllle';
+      const expectedSessionData: WebauthnSessionData = { username: expectedUsername, currentChallenge: expectedChallenge };
+      const expectedSession = { sessionId: expectedSessionId, data: expectedSessionData };
+      const expectedSessionString = JSON.stringify(expectedSessionData);
+      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
+      const expectedCookieValue: RequestCookie | undefined = {
+        name: WEBAUTHN_SESSION_ID_COOKIE_NAME,
+        value: expectedSessionId,
+      };
+      const mockCookieStore = {
+        get: jest.fn().mockReturnValue(expectedCookieValue),
+        set: jest.fn(),
+      };
+      (mockCookies as jest.Mock).mockResolvedValue(mockCookieStore);
+      (mockRedis.get as jest.Mock).mockResolvedValue(expectedSessionString);
+
+
+      // Act
+      const actualSession = await getCurrentWebauthnSession();
+
+      // Assert
+      expect(actualSession).toEqual(expectedSession);
+      expect(mockCookies).toHaveBeenCalled();
+      expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
+      expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
+    });
+  });
+});

--- a/app/lib/session.test.ts
+++ b/app/lib/session.test.ts
@@ -184,12 +184,6 @@ describe('session', () => {
   describe('deleteSession', () => {
     test('no cookie present', async () => {
       // Arrange
-      const expectedChallenge = undefined;
-      const expectedSessionId = 'lllllllllle';
-      const expectedSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
-      const expectedSessionString = JSON.stringify(expectedSessionData);
-      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
-      const expectedExpirationArgument = 'EX';
       const expectedCookieValue: RequestCookie | undefined = undefined;
       const mockCookieStore = {
         get: jest.fn().mockReturnValue(expectedCookieValue),
@@ -203,19 +197,15 @@ describe('session', () => {
       // Assert
       expect(mockCookies).toHaveBeenCalled();
       expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
-      expect(mockCookieStore.set).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME, expectedSessionId);
-      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
-      expect(mockRedis.del).toHaveBeenCalledWith(expectedRedisKey);
+      expect(mockCookieStore.set).not.toHaveBeenCalled();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+      expect(mockRedis.del).not.toHaveBeenCalled();
     });
 
     test('cookie exists but session is missing/expired on redis', async () => {
       // Arrange
-      const expectedChallenge = undefined;
       const expectedSessionId = 'lllllllllle';
-      const expectedSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
-      const expectedSessionString = JSON.stringify(expectedSessionData);
       const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
-      const expectedExpirationArgument = 'EX';
       const expectedCookieValue: RequestCookie | undefined = {
         name: WEBAUTHN_SESSION_ID_COOKIE_NAME,
         value: expectedSessionId,
@@ -235,9 +225,9 @@ describe('session', () => {
       expect(mockCookies).toHaveBeenCalled();
       expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
       expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
-      expect(mockCookieStore.set).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME, expectedSessionId);
-      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
-      expect(mockRedis.del).toHaveBeenCalledWith(expectedRedisKey);
+      expect(mockCookieStore.set).not.toHaveBeenCalled();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+      expect(mockRedis.del).not.toHaveBeenCalled();
     });
 
     test('cookie exists and session is present on redis', async () => {
@@ -274,14 +264,8 @@ describe('session', () => {
   describe('updateCurrentWebauthnSession', () => {
     test('no cookie present', async () => {
       // Arrange
-      const expectedChallenge = undefined;
-      const expectedSessionId = 'lllllllllle';
-      const expectedSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
-      const expectedNewSessionData: WebauthnSessionData = { currentChallenge: '1' };
-      const expectedSessionString = JSON.stringify(expectedSessionData);
-      const expectedNewSessionString = JSON.stringify(expectedSessionData);
-      const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
-      const expectedExpirationArgument = 'EX';
+      const expectedChallenge = '1';
+      const expectedNewSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
       const expectedCookieValue: RequestCookie | undefined = undefined;
       const mockCookieStore = {
         get: jest.fn().mockReturnValue(expectedCookieValue),
@@ -295,9 +279,9 @@ describe('session', () => {
       // Assert
       expect(mockCookies).toHaveBeenCalled();
       expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
-      expect(mockCookieStore.set).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME, expectedSessionId);
-      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
-      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedNewSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
+      expect(mockCookieStore.set).not.toHaveBeenCalled();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+      expect(mockRedis.set).not.toHaveBeenCalled();
     });
 
     test('cookie exists but session is missing/expired on redis', async () => {
@@ -307,7 +291,7 @@ describe('session', () => {
       const expectedSessionData: WebauthnSessionData = { currentChallenge: expectedChallenge };
       const expectedNewSessionData: WebauthnSessionData = { currentChallenge: '1' };
       const expectedSessionString = JSON.stringify(expectedSessionData);
-      const expectedNewSessionString = JSON.stringify(expectedSessionData);
+      const expectedNewSessionString = JSON.stringify(expectedNewSessionData);
       const expectedRedisKey = WEBAUTHN_SESSION_PREFIX + expectedSessionId;
       const expectedExpirationArgument = 'EX';
       const expectedCookieValue: RequestCookie | undefined = {
@@ -330,7 +314,7 @@ describe('session', () => {
       expect(mockCookieStore.get).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME);
       expect(mockRedis.get).toHaveBeenCalledWith(expectedRedisKey);
       expect(mockCookieStore.set).toHaveBeenCalledWith(WEBAUTHN_SESSION_ID_COOKIE_NAME, expectedSessionId);
-      expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
+      expect(mockRedis.set).not.toHaveBeenCalledWith(expectedRedisKey, expectedSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
       expect(mockRedis.set).toHaveBeenCalledWith(expectedRedisKey, expectedNewSessionString, expectedExpirationArgument, WEBAUTHN_SESSION_TTL);
     });
 

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -5,41 +5,41 @@ import { Base64URLString } from '@simplewebauthn/server';
 import { WEBAUTHN_SESSION_ID_COOKIE_NAME, WEBAUTHN_SESSION_PREFIX, WEBAUTHN_SESSION_TTL } from './constants';
 
 export type WebauthnSessionData = {
-    currentChallenge?: Base64URLString;
-    username?: string;
+  currentChallenge?: Base64URLString;
+  username?: string;
 };
 
 async function getSessionData<T>(prefix: string, sessionId: string): Promise<T> {
-    const sessionData = await redis.get(prefix + sessionId);
-    return sessionData ? JSON.parse(sessionData) : null as T;
+  const sessionData = await redis.get(prefix + sessionId);
+  return sessionData ? JSON.parse(sessionData) : (null as T);
 }
 
 export async function getWebauthnSession(sessionId: string): Promise<WebauthnSessionData> {
-    return getSessionData<WebauthnSessionData>(WEBAUTHN_SESSION_PREFIX, sessionId);
+  return getSessionData<WebauthnSessionData>(WEBAUTHN_SESSION_PREFIX, sessionId);
 }
 
 async function setSession<T>(prefix: string, sessionId: string, sessionData: T, ttl: number): Promise<void> {
-    await redis.set(prefix + sessionId, JSON.stringify(sessionData), 'EX', ttl);
+  await redis.set(prefix + sessionId, JSON.stringify(sessionData), 'EX', ttl);
 }
 
 export async function setWebauthnSession(sessionId: string, sessionData: WebauthnSessionData): Promise<void> {
-    await setSession(WEBAUTHN_SESSION_PREFIX, sessionId, sessionData, WEBAUTHN_SESSION_TTL);
+  await setSession(WEBAUTHN_SESSION_PREFIX, sessionId, sessionData, WEBAUTHN_SESSION_TTL);
 }
 
 async function fetchCurrentSession<T>(
-    cookieName: string,
-    fetchSession: (sessionId: string) => Promise<T>,
+  cookieName: string,
+  fetchSession: (sessionId: string) => Promise<T>,
 ): Promise<{ sessionId: string; data: T } | null> {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get(cookieName);
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(cookieName);
 
-    if (sessionCookie?.value) {
-        const session = await fetchSession(sessionCookie.value);
-        if (session) {
-            return { sessionId: sessionCookie.value, data: session };
-        }
+  if (sessionCookie?.value) {
+    const session = await fetchSession(sessionCookie.value);
+    if (session) {
+      return { sessionId: sessionCookie.value, data: session };
     }
-    return null;
+  }
+  return null;
 }
 
 async function createNewSession<T>(
@@ -47,64 +47,67 @@ async function createNewSession<T>(
   updateSession: (sessionId: string, sessionData: T) => Promise<void>,
   newSessionData: T,
 ): Promise<{ sessionId: string; data: T }> {
-    const cookieStore = await cookies();
-    const newSessionId = Math.random().toString(36).slice(2);
-    cookieStore.set(cookieName, newSessionId);
-    await updateSession(newSessionId, newSessionData);
-    return { sessionId: newSessionId, data: newSessionData };
+  const cookieStore = await cookies();
+  const newSessionId = Math.random().toString(36).slice(2);
+  cookieStore.set(cookieName, newSessionId);
+  await updateSession(newSessionId, newSessionData);
+  return { sessionId: newSessionId, data: newSessionData };
 }
 
 export async function getCurrentWebauthnSession(): Promise<{ sessionId: string; data: WebauthnSessionData }> {
-    const session = await fetchCurrentSession<WebauthnSessionData>(
-        WEBAUTHN_SESSION_ID_COOKIE_NAME,
-        getWebauthnSession,
-    );
-    if (session) {
-        return session;
-    }
-    return createNewSession<WebauthnSessionData>(WEBAUTHN_SESSION_ID_COOKIE_NAME, setWebauthnSession, {
-        currentChallenge: undefined,
-        username: undefined,
-    });
+  const session = await fetchCurrentSession<WebauthnSessionData>(WEBAUTHN_SESSION_ID_COOKIE_NAME, getWebauthnSession);
+  if (session) {
+    return session;
+  }
+  return createNewSession<WebauthnSessionData>(WEBAUTHN_SESSION_ID_COOKIE_NAME, setWebauthnSession, {
+    currentChallenge: undefined,
+    username: undefined,
+  });
 }
 
-async function deleteSession(
-    getSession: () => Promise<{ sessionId: string } | null>
-): Promise<void> {
-    const session = await getSession();
-    if (session) {
-        const { sessionId } = session;
-        await redis.del(WEBAUTHN_SESSION_PREFIX + sessionId);
-    }
+async function deleteSession(getSession: () => Promise<{ sessionId: string } | null>): Promise<void> {
+  const session = await getSession();
+  if (session) {
+    const { sessionId } = session;
+    await redis.del(WEBAUTHN_SESSION_PREFIX + sessionId);
+  }
 }
 
 export async function deleteCurrentWebauthnSession(): Promise<void> {
-    const getCurSession = (fetchCurrentSession<WebauthnSessionData>).bind(null, WEBAUTHN_SESSION_ID_COOKIE_NAME, getWebauthnSession);
-    await deleteSession(getCurSession);
+  const getCurSession = (fetchCurrentSession<WebauthnSessionData>).bind(
+    null,
+    WEBAUTHN_SESSION_ID_COOKIE_NAME,
+    getWebauthnSession,
+  );
+  await deleteSession(getCurSession);
 }
 
 async function updateSession<T>(
-    cookieName: string,
-    getSession: () => Promise<{ sessionId: string; data: T } | null>,
-    setSession: (sessionId: string, sessionData: T) => Promise<void>,
-    createSession: (sessionData: T) => Promise<{ sessionId: string; data: T }>,
-    newData: T
+  cookieName: string,
+  getSession: () => Promise<{ sessionId: string; data: T } | null>,
+  setSession: (sessionId: string, sessionData: T) => Promise<void>,
+  createSession: (sessionData: T) => Promise<{ sessionId: string; data: T }>,
+  newData: T,
 ): Promise<void> {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get(cookieName);
-    if (sessionCookie?.value) {
-        const session = await getSession();
-        if (session) {
-            const { sessionId, data: oldData } = session;
-            await setSession(sessionId, { ...oldData, ...newData });
-        } else {
-            await createSession(newData);
-        }
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(cookieName);
+  if (sessionCookie?.value) {
+    const session = await getSession();
+    if (session) {
+      const { sessionId, data: oldData } = session;
+      await setSession(sessionId, { ...oldData, ...newData });
+    } else {
+      await createSession(newData);
     }
+  }
 }
 
 export async function updateCurrentWebauthnSession(data: WebauthnSessionData): Promise<void> {
-    const getCurSession = (fetchCurrentSession<WebauthnSessionData>).bind(null, WEBAUTHN_SESSION_ID_COOKIE_NAME, getWebauthnSession);
-    const newSession = (createNewSession<WebauthnSessionData>).bind(null, WEBAUTHN_SESSION_ID_COOKIE_NAME, setWebauthnSession);
-    await updateSession(WEBAUTHN_SESSION_ID_COOKIE_NAME, getCurSession, setWebauthnSession, newSession, data);
+  await updateSession(
+    WEBAUTHN_SESSION_ID_COOKIE_NAME,
+    (fetchCurrentSession<WebauthnSessionData>).bind(null, WEBAUTHN_SESSION_ID_COOKIE_NAME, getWebauthnSession),
+    setWebauthnSession,
+    (createNewSession<WebauthnSessionData>).bind(null, WEBAUTHN_SESSION_ID_COOKIE_NAME, setWebauthnSession),
+    data,
+  );
 }

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -2,12 +2,9 @@ import { cookies } from 'next/headers';
 
 import redis from './redis';
 import { Base64URLString } from '@simplewebauthn/server';
+import { WEBAUTHN_SESSION_ID_COOKIE_NAME, WEBAUTHN_SESSION_PREFIX, WEBAUTHN_SESSION_TTL } from './constants';
 
-const WEBAUTHN_SESSION_ID_COOKIE_NAME = 'w-session-id';
-const WEBAUTHN_SESSION_PREFIX = 'techwear-shop-webauthn-session-';
-const WEBAUTHN_SESSION_TTL = 5 * 60;
-
-type WebauthnSessionData = {
+export type WebauthnSessionData = {
     currentChallenge?: Base64URLString;
     username?: string;
 };
@@ -21,7 +18,7 @@ export async function getWebauthnSession(sessionId: string): Promise<WebauthnSes
     return getSessionData<WebauthnSessionData>(WEBAUTHN_SESSION_PREFIX, sessionId);
 }
 
-export async function setSession<T>(prefix: string, sessionId: string, sessionData: T, ttl: number): Promise<void> {
+async function setSession<T>(prefix: string, sessionId: string, sessionData: T, ttl: number): Promise<void> {
     await redis.set(prefix + sessionId, JSON.stringify(sessionData), 'EX', ttl);
 }
 

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -11,7 +11,7 @@ export type WebauthnSessionData = {
 
 async function getSessionData<T>(prefix: string, sessionId: string): Promise<T> {
     const sessionData = await redis.get(prefix + sessionId);
-    return sessionData ? JSON.parse(sessionData) : {} as T;
+    return sessionData ? JSON.parse(sessionData) : null as T;
 }
 
 export async function getWebauthnSession(sessionId: string): Promise<WebauthnSessionData> {

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -57,11 +57,11 @@ export async function getCurrentWebauthnSession(): Promise<{ sessionId: string; 
     );
 }
 
-export async function deleteSession(
+async function deleteSession(
     getSession: () => Promise<{ sessionId: string }>
 ): Promise<void> {
     const { sessionId } = await getSession();
-    await redis.del(sessionId);
+    await redis.del(WEBAUTHN_SESSION_PREFIX + sessionId);
 }
 
 export async function deleteCurrentWebauthnSession(): Promise<void> {

--- a/app/lib/webauthn.test.ts
+++ b/app/lib/webauthn.test.ts
@@ -65,7 +65,7 @@ jest.mock('@simplewebauthn/server', () => ({
 
 describe('webauthn', () => {
   describe('generateWebAuthnRegistrationOptions', () => {
-    test(USER_ALREADY_EXISTS_ERROR_MESSAGE, async () => {
+    test('user already exists', async () => {
       // Arrange
       const expectedUsername = 'test';
       const expectedUserId = 'uuid-uuid-uuid-uuid';

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';


### PR DESCRIPTION
Moved WebAuthn session constants to a separate file for better organization. Updated the `setSession` function to a local export and added missing tests for `getWebauthnSession`, `setWebauthnSession`, and `getCurrentWebauthnSession` to ensure functionality. Minor style updates in test setup.